### PR TITLE
Change skip tag from ci to release [skip release]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,12 +69,12 @@ jobs:
       - name: Run tests
         run: yarn test:eslint-plugin-axios
 
-  update-versions:
-    name: 'Publish to NPM'
+  release-version:
+    name: 'Release new version to NPM'
 
     needs: ['prettier', 'eslint', 'test-eslint-plugin-axios']
 
-    if: "github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'skip publish')"
+    if: "github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'skip release')"
 
     runs-on: ubuntu-latest
 

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
   "command": {
     "publish": {
       "ignoreChanges": ["**/README.md", "**/__tests__/**"],
-      "message": "chore(release): publish %s [skip publish]"
+      "message": "chore(release): publish %s [skip release]"
     }
   },
   "packages": ["packages/*"]


### PR DESCRIPTION
Commits can include `[skip release]` to avoid releasing a new version after merging to main.

It turns out Github already detects `[skip ci]` and skips all actions ([details](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/)). This conflicts with the current attempt to use the same tag.

The original tag, `skip ci`, doesn't accurately represent what this was trying to do anyway. We actually want to skip _releases_. Other CI checks (linting, etc.) should probably still run in these cases.