### PR TITLE
Run a single lerna command to increment versions and publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,9 @@ jobs:
       - name: Installing dependencies
         run: yarn install --frozen-lockfile
 
-      # Creates the new version and publishes to github
+      # Increments package versions based on commits since the last release and publishes the new version to github.
+      # Version increments follow the Conventional Commits specification.
+      # See: https://www.conventionalcommits.org/en/v1.0.0/
       - name: Release new version and publish to NPM
         run: npx lerna publish --conventional-commits --exact --yes
         env:


### PR DESCRIPTION
Turns out `lerna publish` does not work if `lerna version` is run first.